### PR TITLE
bugfix: Update metaGEM.sh

### DIFF
--- a/workflow/metaGEM.sh
+++ b/workflow/metaGEM.sh
@@ -267,7 +267,7 @@ snakeConfig() {
 
     # Show config.yaml params
     echo -e "\nPlease verify parameters set in the config.yaml file: \n"
-    paste config.yaml
+    paste ../config/config.yaml
     echo -e "\nPlease pay close attention to make sure that your paths are properly configured!"
 
     while true; do


### PR DESCRIPTION
Fix path to `config.yaml` file for `metaGEM.sh` script. 

As mentioned in #150, the `metaGEM.sh` wrapper cannot find the config file in question, a bug that was introduced after restructuring the repo to be compliant with the snakemake workflow catalogue [rules](https://snakemake.github.io/snakemake-workflow-catalog/?rules=true).